### PR TITLE
Dispose UI controllers before calling super.dispose()

### DIFF
--- a/lib/view/forgot_password/forgot_password.dart
+++ b/lib/view/forgot_password/forgot_password.dart
@@ -22,11 +22,10 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
     @override
 
     void dispose() {
-      // TODO: implement dispose
-      super.dispose();
-
       emailController.dispose();
       emailFocusNode.dispose();
+
+      super.dispose();
 
     }
 

--- a/lib/view/login/login_screen.dart
+++ b/lib/view/login/login_screen.dart
@@ -25,14 +25,13 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
 
   void dispose() {
-    // TODO: implement dispose
-    super.dispose();
-
     emailController.dispose();
     passwordController.dispose();
 
     emailFocusNode.dispose();
     passwordFocusNode.dispose();
+
+    super.dispose();
 
   }
 

--- a/lib/view/signup/Admin/admin_signup_screen.dart
+++ b/lib/view/signup/Admin/admin_signup_screen.dart
@@ -34,14 +34,21 @@ class _AdminSignupScreenState extends State<AdminSignupScreen> {
   @override
 
   void dispose() {
-    // TODO: implement dispose
-    super.dispose();
-
+    usernameController.dispose();
+    courseNametController.dispose();
+    phoneNumberController.dispose();
     emailController.dispose();
     passwordController.dispose();
+    confirmPassController.dispose();
 
     emailFocusNode.dispose();
     passwordFocusNode.dispose();
+    confirmPassFocusNode.dispose();
+    usernameFocusNode.dispose();
+    phoneNumberFocusNode.dispose();
+    courseNameFocusNode.dispose();
+
+    super.dispose();
 
   }
 

--- a/lib/view/signup/user/user_signup_screen.dart
+++ b/lib/view/signup/user/user_signup_screen.dart
@@ -34,14 +34,21 @@ class _UserSignUpScreenState extends State<UserSignUpScreen> {
   @override
 
   void dispose() {
-    // TODO: implement dispose
-    super.dispose();
-
+    usernameController.dispose();
+    studentIdController.dispose();
+    phoneNumberController.dispose();
     emailController.dispose();
     passwordController.dispose();
+    confirmPassController.dispose();
 
     emailFocusNode.dispose();
     passwordFocusNode.dispose();
+    confirmPassFocusNode.dispose();
+    usernameFocusNode.dispose();
+    phoneNumberFocusNode.dispose();
+    studentIdFocusNode.dispose();
+
+    super.dispose();
 
   }
 


### PR DESCRIPTION
## Summary
- clean up screen disposal order by disposing controllers and focus nodes before calling `super.dispose`
- remove leftover comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e5c6cff648331b41ab95820129e26